### PR TITLE
Modify getCodeFromName() to handle null $name

### DIFF
--- a/src/Country.php
+++ b/src/Country.php
@@ -93,7 +93,7 @@ class Country
     public static function getCodeFromName($name, $fallback = 'US')
     {
         $data = self::initData();
-        if (! $data->hasKey('countries', $name)) {
+        if (! $name || ! $data->hasKey('countries', $name)) {
             return $fallback;
         }
 


### PR DESCRIPTION
Modify `getCodeFromName()` to return the default when `$name` is a falsey
value.

This addresses the problem of `getCodeFromName()` returning an Anonymous Proxy when `$name` is `NULL`.

See #3