### PR TITLE
use https url instead of http

### DIFF
--- a/src/Country.php
+++ b/src/Country.php
@@ -29,7 +29,7 @@ class Country
 
     const DB_FILENAME = 'iso3166';
     const DB_FOLDER   = 'data';
-    const DB_URL      = 'http://dev.maxmind.com/static/csv/codes/iso3166.csv';
+    const DB_URL      = 'https://dev.maxmind.com/static/csv/codes/iso3166.csv';
 
     /**
      * The configuration data that is queried.


### PR DESCRIPTION
Maxmind no longer serves http urls, so this fix should make `composer install` work again.