### PR TITLE
Update DB_URL

### DIFF
--- a/src/Country.php
+++ b/src/Country.php
@@ -29,7 +29,7 @@ class Country
 
     const DB_FILENAME = 'iso3166';
     const DB_FOLDER   = 'data';
-    const DB_URL      = 'https://dev.maxmind.com/csv-files/codes/iso3166.csv';
+    const DB_URL      = 'https://dev.maxmind.com/static/csv/codes/iso3166.csv?lang=en';
 
     /**
      * The configuration data that is queried.


### PR DESCRIPTION
### Issue

It seems like the URL which contains the `iso3166.csv` was updated. `https://dev.maxmind.com/csv-files/codes/iso3166.csv` is returning "Redirecting to /static/csv/codes/iso3166.csv" which causes the `composer install` fail because the generated `iso3166.php` contains
```
array(1) {
  [0]=>
  array(1) {
    [0]=>
    string(44) "Redirecting to /static/csv/codes/iso3166.csv"
  }
}
```
instead of the expected iso3166 data.

See - https://dev.maxmind.com/geoip/legacy/codes?lang=en

### Description
This PR updates `DB_URL`